### PR TITLE
Adding an odyssey project

### DIFF
--- a/content/en/projects/odyssey.md
+++ b/content/en/projects/odyssey.md
@@ -1,0 +1,6 @@
+---
+title: Odyssey
+github_link: https://github.com/kentik/odyssey
+weight: 3
+---
+A Synthetic Kubernetes operator. This operator can be used to create Kentik synthetic tests on a Kubernetes cluster.


### PR DESCRIPTION
Drops a quick link into the blog for the Odyssey project. 